### PR TITLE
Defined LED_BUILTIN

### DIFF
--- a/Esp32_SoilMoisture_WebServer.ino
+++ b/Esp32_SoilMoisture_WebServer.ino
@@ -9,6 +9,8 @@ const char* ssid = "xxxxxxxx";
 const char* password = "xxxxxxxxx";
 int port=80;
 
+#define LED_BUILTIN 2 
+
 WebServer server(port);
 
 const int led = LED_BUILTIN;


### PR DESCRIPTION
The master copy of the Sketch/Code did not #include LED_BUILTIN. So I added "#define LED_BUILTIN 2 on line #12". The Sketch/Code runs as expected now.